### PR TITLE
Make named sections in the navigation sidebar collapsible

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -8,11 +8,12 @@
       ds-c-vertical-nav__label--parent
     "
     title="Collapse sub-navigation"
+    aria-controls="collapsible_for_{{forloop.index}}"
     aria-expanded="true"
   >
     {{ item.section}}
   </button>
-  <ul class="ds-c-vertical-nav__subnav">
+  <ul class="ds-c-vertical-nav__subnav" id="collapsible_for_{{forloop.index}}">
     {% for sub in item.items %}
     <li class="ds-c-vertical-nav__item">
       <a class="ds-c-vertical-nav__label" href="{{ "/" | append: item.subdir | append: "/" | append: sub.title | prepend: site.baseurl }}">
@@ -30,3 +31,24 @@
 </li>
 {% endif %}
 {% endfor %}
+
+<script type="text/javascript">
+  (function() {
+    function toggleNav(e) {
+      const button = e.target;
+      const isExpanded = button.getAttribute("aria-expanded") === "true";
+      const controlledID = button.getAttribute("aria-controls");
+      const controlled = document.getElementById(controlledID);
+
+      controlled.style.display = isExpanded ? "none": "";
+      button.setAttribute("aria-expanded", `${!isExpanded}`);
+    }
+
+    Array.from(
+      document.querySelectorAll("button.ds-c-vertical-nav__label[aria-controls]")
+    ).forEach(function(b) {
+      b.addEventListener("click", toggleNav);
+    });
+    
+  })();
+</script>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -32,23 +32,9 @@
 {% endif %}
 {% endfor %}
 
-<script type="text/javascript">
-  (function() {
-    function toggleNav(e) {
-      const button = e.target;
-      const isExpanded = button.getAttribute("aria-expanded") === "true";
-      const controlledID = button.getAttribute("aria-controls");
-      const controlled = document.getElementById(controlledID);
-
-      controlled.style.display = isExpanded ? "none": "";
-      button.setAttribute("aria-expanded", `${!isExpanded}`);
-    }
-
-    Array.from(
-      document.querySelectorAll("button.ds-c-vertical-nav__label[aria-controls]")
-    ).forEach(function(b) {
-      b.addEventListener("click", toggleNav);
-    });
-    
-  })();
-</script>
+<script
+  id="toc-script"
+  type="text/javascript"
+  src="{{ "/assets/js/toc-expand-collapse.js" | prepend: site.baseurl }}"
+  data-path="{{ site.baseurl }}"
+></script>

--- a/assets/js/toc-expand-collapse.js
+++ b/assets/js/toc-expand-collapse.js
@@ -1,0 +1,48 @@
+(function setupNavbarExpansion() {
+  const path = document.getElementById("toc-script").getAttribute("data-path");
+
+  // Load the toc expansion state from cookies, if they exist.
+  const expandStateCookie = document.cookie.match(
+    /(^|\s)expandState=(.*?);/
+  ) || [null, null, "{}"];
+  const expandState = JSON.parse(decodeURIComponent(expandStateCookie[2]));
+
+  function toggleNav(e) {
+    const button = e.target;
+    const isExpanded = button.getAttribute("aria-expanded") === "true";
+    const controlledID = button.getAttribute("aria-controls");
+    const controlled = document.getElementById(controlledID);
+
+    controlled.style.display = isExpanded ? "none" : "";
+    button.setAttribute("aria-expanded", `${!isExpanded}`);
+
+    // Update the expand state with the new info, then store that in a cookie.
+    // Need to set the path on the cookie so that all pages within this site
+    // will use the same one; otherwise, the pages in subdirectories will
+    // control a seprate cookie. Also keep the cookie around for a year.
+    Object.assign(expandState, { [controlledID]: !isExpanded });
+    document.cookie = [
+      "expandState=",
+      encodeURIComponent(JSON.stringify(expandState)),
+      ";path=",
+      path,
+      ";max-age=",
+      365 * 24 * 60 * 60, // a year in seconds
+    ].join("");
+  }
+
+  Array.from(
+    document.querySelectorAll("button.ds-c-vertical-nav__label[aria-controls]")
+  ).forEach(function (button) {
+    button.addEventListener("click", toggleNav);
+
+    const controlledID = button.getAttribute("aria-controls");
+
+    // If the expand-controlled element exists in the known expansion state,
+    // update the DOM accordingly.
+    if (typeof expandState[controlledID] === "boolean") {
+      const controlled = document.getElementById(controlledID);
+      controlled.style.display = expandState[controlledID] ? "" : "none";
+    }
+  });
+})();

--- a/assets/js/toc-expand-collapse.js
+++ b/assets/js/toc-expand-collapse.js
@@ -14,7 +14,7 @@
     const controlled = document.getElementById(controlledID);
 
     controlled.style.display = isExpanded ? "none" : "";
-    button.setAttribute("aria-expanded", `${!isExpanded}`);
+    button.setAttribute("aria-expanded", !isExpanded);
 
     // Update the expand state with the new info, then store that in a cookie.
     // Need to set the path on the cookie so that all pages within this site
@@ -41,6 +41,7 @@
     // If the expand-controlled element exists in the known expansion state,
     // update the DOM accordingly.
     if (typeof expandState[controlledID] === "boolean") {
+      button.setAttribute("aria-expanded", expandState[controlledID]);
       const controlled = document.getElementById(controlledID);
       controlled.style.display = expandState[controlledID] ? "" : "none";
     }


### PR DESCRIPTION
This pull request resolves #35

**Description-**

Any section in the sidebar that has subsections is now collapsible by clicking on the title of the section.

![animated screenshot showing the collapsing and expanding navigation section](https://user-images.githubusercontent.com/1775733/134412841-4c4af3c6-8f35-4784-a6b0-add6befc68fa.gif)

**This pull request changes...**

- links the clickable section title to the list of subsections with ARIA attributes
- on click, updates the ARIA attributes and toggles subsection visibility

**Steps to manually review and verify this change...**

1. open the site
2. clicky the nav thingy, observe that the subsections appear and disappear accordingly
3. observed that the expand/collapse arrows update accordingly
4. use the browser element inspector to observe that the `aria-expanded` property of the nav section toggles between `true` and `false`

### This pull request can be merged when…

- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The change has been reviewed and approved by CMS
