### PR TITLE
Apply design system classes to all tables

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,5 +39,12 @@
     </main>
     {%include footer.html %}
     <script src="{{ "/assets/components/index.js" | prepend: site.baseurl }}"></script>
+    <script type="text/javascript">
+      (function makeTablesComplyWithDesignSystem() {
+        Array.from(document.querySelectorAll("table")).forEach(function(table) {
+          table.setAttribute("class", "ds-c-table ds-text-body--sm")
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This pull request resolves #40

**Description**

There's no way in pure markdown to set CSS classes or styles for tables. This PR adds a little script that runs when the page is first loaded to programmatically add the `ds-c-table` and `ds-text-body--sm` classes to all tables.

---
![screenshot showing the updated table styles](https://user-images.githubusercontent.com/1775733/134525393-439500d3-81b1-44e7-90c3-3c6887293a6c.png)
---

**This pull request changes...**

- all tables have the `ds-c-table` and `ds-text-body--sm` CSS classes

**Steps to manually review and verify this change...**

1. look and seeeee!

### This pull request can be merged when…

- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The change has been reviewed and approved by CMS
