### PR TITLE
Updates all pages with correct email address and working hyperlink

### DIFF
--- a/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
+++ b/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
@@ -27,7 +27,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Asset Verification System/readme.md
+++ b/Outcomes and Metrics/Asset Verification System/readme.md
@@ -28,7 +28,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Claims Processing/readme.md
+++ b/Outcomes and Metrics/Claims Processing/readme.md
@@ -35,7 +35,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
+++ b/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
@@ -27,7 +27,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
+++ b/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
@@ -29,7 +29,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Eligibility and Enrollment/readme.md
+++ b/Outcomes and Metrics/Eligibility and Enrollment/readme.md
@@ -56,7 +56,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
+++ b/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
@@ -33,7 +33,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Financial Management/readme.md
+++ b/Outcomes and Metrics/Financial Management/readme.md
@@ -38,7 +38,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
+++ b/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
@@ -26,7 +26,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
+++ b/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
@@ -40,7 +40,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Member Management/readme.md
+++ b/Outcomes and Metrics/Member Management/readme.md
@@ -39,7 +39,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
+++ b/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
@@ -38,7 +38,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
+++ b/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
@@ -36,7 +36,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Provider Management/readme.md
+++ b/Outcomes and Metrics/Provider Management/readme.md
@@ -49,7 +49,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/Outcomes and Metrics/Public Health/readme.md
+++ b/Outcomes and Metrics/Public Health/readme.md
@@ -1,1 +1,0 @@
-[PUT CONTENT HERE]

--- a/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
+++ b/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
@@ -41,7 +41,7 @@ When state-specific outcomes statements, keep [these tips](https://cmsgov.github
 
 We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
 
-Please send examples from your state that you'd like to share to OutcomesRepoFeedback@hhs.cms.org. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
 
 
 

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -9,6 +9,7 @@ toc:
       # then the toc.html include will need to be modified.
       - title: 1115 or Waiver Support Systems
       - title: Asset Verification System
+      - title: Claims Processing
       - title: Decision Support System & Data Warehouse
       - title: Electronic Visit Verification (EVV)
       - title: Eligibility and Enrollment

--- a/certification-process.md
+++ b/certification-process.md
@@ -27,7 +27,7 @@ The CMS Certification Repository is a space for states, CMS, and vendors to lear
 ## From this repo states can: 
 - Find examples and expectations for developing outcomes and metrics
 - Share outcomes and metrics with other states and see examples of what other states have created
-- Suggest changes and provide feedback to CMS regarding outcomes requirements and processes (email MESCertificationRepo@cms.hhs.gov)
+- Suggest changes and provide feedback to CMS regarding outcomes requirements and processes via <MESCertificationRepo@cms.hhs.gov>
 
 ## From this repo CMS will: 
 - Provide publicly available resources to guide states in how to write outcome statements and measure impact
@@ -36,5 +36,5 @@ The CMS Certification Repository is a space for states, CMS, and vendors to lear
 
 ## From this repo vendors can: 
 - Get direct access to the CMS required outcomes or recommended metrics
-- Share suggestions and feedback to CMS regaurding  outcomes requirements and processes (email MESCertificationRepo@cms.hhs.gov)
+- Share suggestions and feedback to CMS regaurding  outcomes requirements and processes via <MESCertificationRepo@cms.hhs.gov>
 

--- a/contact.md
+++ b/contact.md
@@ -2,4 +2,4 @@
 
 The MES team will be iterating on the site over time and would love to know how it can be improved. 
 
-If you have feedback or suggestions for improvent please email them to MESCertificationRepo@cms.hhs.gov and our team will get back to you. 
+If you have feedback or suggestions for improvent please email them to <MESCertificationRepo@cms.hhs.gov> and our team will get back to you. 


### PR DESCRIPTION
This pull request resolves #21 

**This pull request changes...**

- every email address reference in the site should now be: MESCertificationRepo@cms.hhs.gov
- every email address on the site should be hyperlinked

**Steps to manually review and verify this change...**

1. Review files changed tab in the PR to confirm addresses are correct.

### This pull request can be merged when…

- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The change has been reviewed and approved by CMS
