### PR TITLE
Fix cookie processing bug

### DIFF
--- a/assets/js/toc-expand-collapse.js
+++ b/assets/js/toc-expand-collapse.js
@@ -2,10 +2,15 @@
   const path = document.getElementById("toc-script").getAttribute("data-path");
 
   // Load the toc expansion state from cookies, if they exist.
-  const expandStateCookie = document.cookie.match(
-    /(^|\s)expandState=(.*?);/
-  ) || [null, null, "{}"];
-  const expandState = JSON.parse(decodeURIComponent(expandStateCookie[2]));
+  const cookie = (
+    document.cookie
+      .split(";")
+      .filter(function (c) {
+        return c.trim().substr(0, 12) === "expandState=";
+      })
+      .pop() || "={}"
+  ).split("=")[1];
+  const expandState = JSON.parse(decodeURIComponent(cookie));
 
   function toggleNav(e) {
     const button = e.target;


### PR DESCRIPTION
This pull request resolves #51

**Description**

The cookie parsing logic assumed that a cookie would always be terminated with a `;` semicolon character. However, the semicolon is only used as a separator value between cookies and is not present if there is only one cookie.

This PR changes the parsing logic to be more resilient. It removes the regular expression in favor of a few logical steps (split the cookie string into subcomponents based on semicolon; find the subcomponent that starts with `expandState=`; use that as the state value) that should be easier to maintain.

**This pull request changes...**

- fixes a bug where the sidebar collapse state may not work correctly in cases where there is only a single cookie for the site

**Steps to manually review and verify this change...**

1. try it and let's hope for the best, but the bug makes total sense to me and I could reliably reproduce it. It appears to be mitigated.

### This pull request can be merged when…

- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The change has been reviewed and approved by CMS
