### PR TITLE
Move the Google Analytics tag into the default layout so it's on every page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,5 +49,14 @@
         });
       })();
     </script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PKN55Q7KS5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-PKN55Q7KS5');
+    </script>
   </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -4,14 +4,4 @@ description: This is a documentation page.
 layout: post
 ---
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-PKN55Q7KS5"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-PKN55Q7KS5');
-</script>
-
 {% include_relative readme.md %}


### PR DESCRIPTION
This pull request resolves #70 (maybe maybe)

**This pull request changes...**
- puts the Google Analytics tag on every page

**Steps to manually review and verify this change...**
1. see if all the pages show up in Google Analytics, I guess? 😬 

### This pull request can be merged when…
- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The pull request author has assigned a CMS reviewer
- [ ] The change has been reviewed and approved by CMS
