### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello


### PR DESCRIPTION
This PR creates a baseline CircleCI configuration so that the repo will trigger builds there. (Nick already created the config, just need to merge it, or not [see below].)

# NOTE
I'm not 100% sure this repo needs to be configured with CircleCI, so @JAMAMIL or @NAretakis please weigh in. The actual question is:

### Which repo is production, and which is staging?

The staging repo needs to trigger events on CircleCI. The production repo needs to _accept_ data from CircleCI, so for that one we'll probably need to setup a deploy key. Which will be fun... But that's a bridge to cross tomorrow.
