### PR TITLE
Finalize circleci config and fix repo names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,27 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+  deploy-prod-from-main:
     docker:
       - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:
       - checkout
+      # Add deployment key fingerprint from prod repo for CircleCI to use for a push at https://github.com/CMSgov/MESCertificationRepo/settings/keys
+      - add_ssh_keys:
+          fingerprints:
+            - "00:5c:4a:a0:67:2f:28:b1:81:83:b2:d3:40:da:c3:5e"
+      # update this line when the repo is renamed
+      - run: git remote add prod_repo git@github.com:CMSgov/MESCertificationRepo.git
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: "Updating prod"
+          command: "git push prod_repo main:main"
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  say-hello-workflow:
+  # Workflow to deploy staging repo changes to prod on changes to main
+  deploy-prod-workflow:
     jobs:
-      - say-hello
+      - deploy-prod-from-main:
+          filters:
+            branches:
+              only:
+                - main

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: New Issue Template
     about: Use this template to create a new issue to track bugs, content updates, feature requests, or more.
-    url: https://github.com/CMSgov/CMCS-DSG-DSS-Certification/issues/new?template=issue_template.md&assignees=&labels=&title=&milestone=&projects=CMSgov/CMCS-DSG-DSS-Certification%2F1
+    url: https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/issues/new?template=issue_template.md&assignees=&labels=&title=&milestone=&projects=CMSgov/CMCS-DSG-DSS-Certification-Staging%2F1

--- a/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
+++ b/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
@@ -1,16 +1,12 @@
 # 1115 or Waiver Support Systems
 
-#### How this system supports the Medicaid Program 
+#### How this system supports the Medicaid Program
 
-Under a Medicaid waiver, a state can waive certain Medicaid eligibility requirements, covering care for people who might not otherwise be eligible for Medicaid. A waiver support system could be any enhancement to an MES module that helps facilitate changes to the Medicaid program operationalized by an approved waiver. 
+Under a Medicaid waiver, a state can waive certain Medicaid eligibility requirements, covering care for people who might not otherwise be eligible for Medicaid. A waiver support system could be any enhancement to an MES module that helps facilitate changes to the Medicaid program operationalized by an approved waiver.
 
-<div align="right">
-  <a href="https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/NAretakis-Navigation-Flat/Outcomes%20and%20Metrics/Claims%20Processing/CMS-Required%20%26%20State%20Specific%20Outcomes.xlsx">Click here to download the outcomes in an Excel Workbook</a>  
-</div>
 ---
 
 ## CMS-Required Outcomes
-
 
 None. There are no CMS-Required outcomes for 1115 or Waiver Support Systems.
 
@@ -20,20 +16,17 @@ As such, for an 1115 or Waiver Support system to be certified states will need t
 
 ## State-Specific Outcomes - CMS Approved
 
-States requesting enhanced FFP for systems that fulfill *state-specific program needs,* beyond minimum legal requirements and the baseline of the *CMS-required outcomes*, should propose *State-Specific Outcomes* which address the proposed enhancements.
+States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind. 
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+
 ### Examples for 1115 or Waiver Support Systems
 
-We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
+We are actively gathering and evaluating outcomes statements crafted by states for this business area.
 
-Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples.
 
-
-
-
-| **State**     | Medicaid Program Goal | Outcome Statement | **Metric(s)** | 
-| ------------- | --------------------- | ----------------- | ------------- | 
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | 
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | 
-
+| **State** | Medicaid Program Goal | Outcome Statement | **Metric(s)** |
+| --------- | --------------------- | ----------------- | ------------- |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        |

--- a/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
+++ b/Outcomes and Metrics/1115 or Waiver Support Systems/readme.md
@@ -10,7 +10,7 @@ Under a Medicaid waiver, a state can waive certain Medicaid eligibility requirem
 
 None. There are no CMS-Required outcomes for 1115 or Waiver Support Systems.
 
-As such, for an 1115 or Waiver Support system to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benetis.
+As such, for an 1115 or Waiver Support system to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benefits.
 
 ---
 
@@ -18,7 +18,7 @@ As such, for an 1115 or Waiver Support system to be certified states will need t
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for 1115 or Waiver Support Systems
 

--- a/Outcomes and Metrics/Asset Verification System/readme.md
+++ b/Outcomes and Metrics/Asset Verification System/readme.md
@@ -1,16 +1,12 @@
-# Asset Verification System 
-#### How this system supports the Medicaid Program 
+# Asset Verification System
+
+#### How this system supports the Medicaid Program
 
 Electronic asset verification systems (AVSs) collect information directly from financial institutions to determine whether certain seniors and people with disabilities who are applying for or receiving Medicaid have assets below eligibility caps.
-
-<div align="right">
-  <a href="https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/NAretakis-Navigation-Flat/Outcomes%20and%20Metrics/Claims%20Processing/CMS-Required%20%26%20State%20Specific%20Outcomes.xlsx">Click here to download the outcomes in an Excel Workbook</a>  
-</div>
 
 ---
 
 ## CMS-Required Outcomes
-
 
 None. There are no CMS-Required outcomes for an Asset Verification System.
 
@@ -20,21 +16,17 @@ As such, for an Asset Verification System to be certified states will need to cr
 
 ## State-Specific Outcomes - CMS Approved
 
-States requesting enhanced FFP for systems that fulfill *state-specific program needs,* beyond minimum legal requirements and the baseline of the *CMS-required outcomes*, should propose *State-Specific Outcomes* which address the proposed enhancements.
+States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.  
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Asset Verification Systems
 
-We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
+We are actively gathering and evaluating outcomes statements crafted by states for this business area.
 
-Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples.
 
-
-
-
-| **State**     | Medicaid Program Goal | Outcome Statement | **Metric(s)** | 
-| ------------- | --------------------- | ----------------- | ------------- | 
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | 
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | 
-
+| **State** | Medicaid Program Goal | Outcome Statement | **Metric(s)** |
+| --------- | --------------------- | ----------------- | ------------- |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        |

--- a/Outcomes and Metrics/Asset Verification System/readme.md
+++ b/Outcomes and Metrics/Asset Verification System/readme.md
@@ -10,7 +10,7 @@ Electronic asset verification systems (AVSs) collect information directly from f
 
 None. There are no CMS-Required outcomes for an Asset Verification System.
 
-As such, for an Asset Verification System to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benetis.
+As such, for an Asset Verification System to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benefits.
 
 ---
 
@@ -18,7 +18,7 @@ As such, for an Asset Verification System to be certified states will need to cr
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Asset Verification Systems
 

--- a/Outcomes and Metrics/Claims Processing/readme.md
+++ b/Outcomes and Metrics/Claims Processing/readme.md
@@ -14,7 +14,7 @@ Claims processing systems cover the ingestion and validation of claims against r
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Claims Processing
 

--- a/Outcomes and Metrics/Claims Processing/readme.md
+++ b/Outcomes and Metrics/Claims Processing/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Claims Processing
 

--- a/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
+++ b/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
@@ -17,7 +17,7 @@ The Decision Support System (DSS) / Data Warehouse (DW) business area covers sof
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv1 %}
 
@@ -27,7 +27,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Decision Support Systems & Data Warehouses
 

--- a/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
+++ b/Outcomes and Metrics/Decision Support System & Data Warehouse/readme.md
@@ -27,7 +27,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Decision Support Systems & Data Warehouses
 

--- a/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
+++ b/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
@@ -8,7 +8,7 @@ EVV is a computer-based system that electronically documents and verifies servic
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 The EVV Required Outcomes and Metrics can be found on the [Medicaid.gov EVV Outcome Based Certification page](https://www.medicaid.gov/medicaid/data-systems/outcomes-based-certification/electronic-visit-verification-certification/index.html). We will be integrating EVV outcomes and metrics into this repo over time.
 
@@ -18,7 +18,7 @@ The EVV Required Outcomes and Metrics can be found on the [Medicaid.gov EVV Outc
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for this Electronic Visit Verification
 

--- a/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
+++ b/Outcomes and Metrics/Electronic Visit Verification (EVV)/readme.md
@@ -1,13 +1,14 @@
 # Electronic Visit Verification (EVV)
-#### How this system supports the Medicaid Program 
 
-EVV is a computer-based system that electronically documents and verifies service delivery information, such as date, time, service type and location, for certain Medicaid service visits that occur in the beneficiary’s home.  
+#### How this system supports the Medicaid Program
+
+EVV is a computer-based system that electronically documents and verifies service delivery information, such as date, time, service type and location, for certain Medicaid service visits that occur in the beneficiary’s home.
 
 ---
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations. 
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
 
 The EVV Required Outcomes and Metrics can be found on the [Medicaid.gov EVV Outcome Based Certification page](https://www.medicaid.gov/medicaid/data-systems/outcomes-based-certification/electronic-visit-verification-certification/index.html). We will be integrating EVV outcomes and metrics into this repo over time.
 
@@ -15,19 +16,17 @@ The EVV Required Outcomes and Metrics can be found on the [Medicaid.gov EVV Outc
 
 ## State-Specific Outcomes - CMS Approved
 
-States requesting enhanced FFP for systems that fulfill *state-specific program needs,* beyond minimum legal requirements and the baseline of the *CMS-required outcomes*, should propose *State-Specific Outcomes* which address the proposed enhancements.
+States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind. 
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+
 ### Examples for this Electronic Visit Verification
 
-We are actively gathering and evaluating outcomes statements crafted by states for this business area. 
+We are actively gathering and evaluating outcomes statements crafted by states for this business area.
 
-Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples. 
+Please send examples from your state that you'd like to share to <MESCertificationRepo@cms.hhs.gov>. Our team will collect and share the best examples.
 
-
-
-
-| **State**     | Medicaid Program Goal | Outcome Statement | **Metric(s)** | 
-| ------------- | --------------------- | ----------------- | ------------- | 
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | &nbsp; |
-| &nbsp; | &nbsp; | &nbsp;| &nbsp; | &nbsp; |
+| **State** | Medicaid Program Goal | Outcome Statement | **Metric(s)** |
+| --------- | --------------------- | ----------------- | ------------- | ------ |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        | &nbsp; |
+| &nbsp;    | &nbsp;                | &nbsp;            | &nbsp;        | &nbsp; |

--- a/Outcomes and Metrics/Eligibility and Enrollment/readme.md
+++ b/Outcomes and Metrics/Eligibility and Enrollment/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Eligibility and Enrollment
 

--- a/Outcomes and Metrics/Eligibility and Enrollment/readme.md
+++ b/Outcomes and Metrics/Eligibility and Enrollment/readme.md
@@ -14,7 +14,7 @@ A system or subsystem that assigns accurate eligibility categories for all appli
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Eligibility and Enrollment
 

--- a/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
+++ b/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
@@ -22,7 +22,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Encounter Processing Systems
 

--- a/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
+++ b/Outcomes and Metrics/Encounter Processing System (EPS) & Managed Care System/readme.md
@@ -14,7 +14,7 @@ Encounter Processing Systems ingest encounter data (submissions and re-submissio
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations. {% include table.html table=csv %}
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations. {% include table.html table=csv %}
 
 ---
 
@@ -22,7 +22,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Encounter Processing Systems
 

--- a/Outcomes and Metrics/Financial Management/readme.md
+++ b/Outcomes and Metrics/Financial Management/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Financial Management
 

--- a/Outcomes and Metrics/Financial Management/readme.md
+++ b/Outcomes and Metrics/Financial Management/readme.md
@@ -14,7 +14,7 @@ A system or subsystem that calculates FFS provider payment or recoupment amounts
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Financial Management
 

--- a/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
+++ b/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
@@ -15,7 +15,7 @@ A Health Information Exchange allows medical information to be accessed and shar
 
 None. There are no CMS-Required outcomes for HIE.
 
-As such, for an HIE system to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benetis.
+As such, for an HIE system to be certified states will need to create or reuse State-Specific Outcomes which target state-specific problems and derive Medicaid program benefits.
 
 ---
 
@@ -23,7 +23,7 @@ As such, for an HIE system to be certified states will need to create or reuse S
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Health Information Exchanges
 

--- a/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
+++ b/Outcomes and Metrics/Health Information Exchange (HIE)/readme.md
@@ -23,7 +23,7 @@ As such, for an HIE system to be certified states will need to create or reuse S
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Health Information Exchanges
 

--- a/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
+++ b/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
@@ -14,7 +14,7 @@ Medicaid is the primary payer across the nation for long-term care services. Med
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Long Term Services & Supports
 

--- a/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
+++ b/Outcomes and Metrics/Long Term Services & Supports (LTSS)/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Long Term Services & Supports
 

--- a/Outcomes and Metrics/Member Management/readme.md
+++ b/Outcomes and Metrics/Member Management/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Member Management
 

--- a/Outcomes and Metrics/Member Management/readme.md
+++ b/Outcomes and Metrics/Member Management/readme.md
@@ -14,7 +14,7 @@ The Member Management module includes the function of determining eligibility fo
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Member Management
 

--- a/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
+++ b/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
@@ -27,7 +27,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Pharmacy Benefit Management
 

--- a/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
+++ b/Outcomes and Metrics/Pharmacy Benefit Management (PBM) & Point of Sale (POS)/readme.md
@@ -17,7 +17,7 @@ Pharmacy Benefit Management (PBM) systems provide services which may include cla
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv1 %}
 
@@ -27,7 +27,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Pharmacy Benefit Management
 

--- a/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
+++ b/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
@@ -14,7 +14,7 @@ PDMP systems monitor the use of controlled substances, including prescription dr
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Prescription Drug Monitoring Programs
 

--- a/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
+++ b/Outcomes and Metrics/Prescription Drug Monitoring Program (PDMP)/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Prescription Drug Monitoring Programs
 

--- a/Outcomes and Metrics/Provider Management/readme.md
+++ b/Outcomes and Metrics/Provider Management/readme.md
@@ -14,7 +14,7 @@ Provider management module includes processes (initial and ongoing) to screen an
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Provider Management
 

--- a/Outcomes and Metrics/Provider Management/readme.md
+++ b/Outcomes and Metrics/Provider Management/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Provider Management
 

--- a/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
+++ b/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/writing-outcome-statements) in mind.
+When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Third Party Liability
 

--- a/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
+++ b/Outcomes and Metrics/Third Party Liability (TPL)/readme.md
@@ -14,7 +14,7 @@ In some cases, Medicaid beneficiaries may have more than one source of coverage 
 
 ## CMS-Required Outcomes
 
-Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that a specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to continue to receive enhanced federal funding for operations.
+Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-Required Outcomes and Metrics are used to demonstrate that a system is compliant with the applicable federal regulations which pertain to that specific system or module. CMS-Required outcomes form the baseline for system/module functionality, which must continue to receive enhanced federal funding for operations.
 
 {% include table.html table=csv %}
 
@@ -24,7 +24,7 @@ Each CMS-Required outcome is based on statutory or regulatory requirements. CMS-
 
 States requesting enhanced FFP for systems that fulfill _state-specific program needs,_ beyond minimum legal requirements and the baseline of the _CMS-required outcomes_, should propose _State-Specific Outcomes_ which address the proposed enhancements.
 
-When state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
+When drafting state-specific outcomes statements, keep [these tips]({{ site.baseurl }}/writing-outcome-statements) in mind.
 
 ### Examples for Third Party Liability
 

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -22,13 +22,12 @@ toc:
       - title: Prescription Drug Monitoring Program (PDMP)
       - title: Provider Management
       - title: Third Party Liability (TPL)
-  - title: Outcomes + the certification process 
+  - title: Outcomes + the certification process
     link: /certification-process
   - title: Writing a good outcome statement
     link: /writing-outcome-statements
   - title: Roadmap
-    url: "https://github.com/CMSgov/CMCS-DSG-DSS-Certification/wiki/MES-Certification-Repo-Roadmap"
+    url: "https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/wiki/MES-Certification-Repo-Roadmap"
     external: true
   - title: Contact Us
     link: /contact
-         

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 The CMS Certification Repository is a space for states, CMS, and vendors to learn, share, and contribute information about the MES Certification process and its related artifacts. From this site you can access the latest-and-greatest information about CMS-Required outcomes and recommended metrics as well as view CMS approved state-specific outcomes and metrics.
 
-# Recent updates
+## Recent updates
 
 This site is intended to be a resource that grows over time. Here are recent updates you may want to know about:
 
@@ -12,7 +12,7 @@ This site is intended to be a resource that grows over time. Here are recent upd
 
 See the [repo roadmap](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/wiki/MES-Certification-Repo-Roadmap) for more details on what is coming for this repository.
 
-# Getting Started
+## Getting Started
 
 The repository is organized by MES business area. Click one of the business areas below to see outcomes and metrics for the specific module/business area you are working on:
 
@@ -33,3 +33,21 @@ The repository is organized by MES business area. Click one of the business area
 - [Third Party Liability (TPL)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Third%20Party%20Liability%20(TPL)>)
 
 _Certification is still required if your project does not fall neatly into one of the above business areas. You may still find relevant outcomes and metrics examples across business areas. As needed, work with your state team and State Officer to create state-specific outcomes statements._
+
+## Contributing
+
+As this site is hosted using GitHub Pages, there is only one preview branch available per repo. In order to provide editors the opportunity to review their changes before publishing to the production site, we have set up both a staging repository and a production repository for this project.
+
+The repo named [CMCS-DSG-DSS-Certification-Staging](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging) will continue to be our working draft, where [issues](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/issues), [pull requests](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/pulls), and the [wiki](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/wiki) are maintained. All site changes merged to the "staging" branch in that repo will display on the staging URL at https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/.
+
+The repo named [CMCS-DSG-DSS-Certification](https://github.com/CMSgov/CMCS-DSG-DSS-Certification) is a mirror of the staging repo's "main" branch, and displays the published state of the site, visible at https://cmsgov.github.io/CMCS-DSG-DSS-Certification/.
+
+### Workflow
+
+1. Continue to open feature branches on the [Staging repo](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging) as before, setting the destination of any pull requests to the "staging" branch.
+2. When you are satisfied with the state of the Staging repo and have tested your changes on the [staging URL](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/), [open a new pull request](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/compare/staging...main) from the "staging" branch to the "main" branch on the Staging repo.
+3. Once that pull request is approved and merged into "main", CircleCI will manage the actual deploy to the production repo for you. You should never need to edit or merge the production repo ([CMCS-DSG-DSS-Certification](https://github.com/CMSgov/CMCS-DSG-DSS-Certification)) directly.
+
+#### Where am I?
+
+Please note that because production is a _mirror_ repo, this readme and all other content will look the identical across both repos. It is important to observe the repo's name and URL to disambiguate between the two.

--- a/readme.md
+++ b/readme.md
@@ -1,35 +1,35 @@
 # Welcome to the CMS Certification Repository
+
 The CMS Certification Repository is a space for states, CMS, and vendors to learn, share, and contribute information about the MES Certification process and its related artifacts. From this site you can access the latest-and-greatest information about CMS-Required outcomes and recommended metrics as well as view CMS approved state-specific outcomes and metrics.
 
 # Recent updates
-This site is intended to be a resource that grows over time. Here are recent updates you may want to know about: 
-* The site was officially shared with states in the Certification Community of Practice on October 12, 2021.
-* The visual styling for tables was merged to improve the look and feel of the site.
-* All business areas/module pages were updated with CMS-Required Outcomes and recommended Metrics
 
-See the [repo roadmap](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/wiki/MES-Certification-Repo-Roadmap) for more details on what is coming for this repository. 
+This site is intended to be a resource that grows over time. Here are recent updates you may want to know about:
+
+- The site was officially shared with states in the Certification Community of Practice on October 12, 2021.
+- The visual styling for tables was merged to improve the look and feel of the site.
+- All business areas/module pages were updated with CMS-Required Outcomes and recommended Metrics
+
+See the [repo roadmap](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/wiki/MES-Certification-Repo-Roadmap) for more details on what is coming for this repository.
 
 # Getting Started
+
 The repository is organized by MES business area. Click one of the business areas below to see outcomes and metrics for the specific module/business area you are working on:
 
-* [1115 or Waiver Support Systems](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/1115%20or%20Waiver%20Support%20Systems/)
-* [Asset Verification System](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Asset%20Verification%20System)
-* [Claims Processing](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Claims%20Processing)
-* [Decision Support System & Data Warehouse](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Decision%20Support%20System%20%26%20Data%20Warehouse)
-* [Electronic Visit Verification (EVV)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Electronic%20Visit%20Verification%20(EVV))
-* [Eligibility and Enrollment](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Eligibility%20and%20Enrollment/)
-* [Encounter Processing System (EPS) & Managed Care System](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Encounter%20Processing%20System%20(EPS)%20%26%20Managed%20Care%20System)
-* [Financial Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Financial%20Management)
-* [Health Information Exchange (HIE)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Health%20Information%20Exchange%20(HIE))
-* [Long Term Services & Supports (LTSS)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Long%20Term%20Services%20%26%20Supports%20(LTSS))
-* [Member Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Member%20Management)
-* [Pharmacy Benefit Management (PBM) & Point of Sale (POS)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Pharmacy%20Benefit%20Management%20(PBM)%20%26%20Point%20of%20Sale%20(POS))
-* [Prescription Drug Monitoring Program (PDMP)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Prescription%20Drug%20Monitoring%20Program%20(PDMP))
-* [Provider Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Provider%20Management)
-* [Third Party Liability (TPL)](https://cmsgov.github.io/CMCS-DSG-DSS-Certification/Outcomes%20and%20Metrics/Third%20Party%20Liability%20(TPL))
+- [1115 or Waiver Support Systems](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/1115%20or%20Waiver%20Support%20Systems/)
+- [Asset Verification System](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Asset%20Verification%20System)
+- [Claims Processing](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Claims%20Processing)
+- [Decision Support System & Data Warehouse](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Decision%20Support%20System%20%26%20Data%20Warehouse)
+- [Electronic Visit Verification (EVV)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Electronic%20Visit%20Verification%20(EVV)>)
+- [Eligibility and Enrollment](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Eligibility%20and%20Enrollment/)
+- [Encounter Processing System (EPS) & Managed Care System](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Encounter%20Processing%20System%20(EPS)%20%26%20Managed%20Care%20System>)
+- [Financial Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Financial%20Management)
+- [Health Information Exchange (HIE)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Health%20Information%20Exchange%20(HIE)>)
+- [Long Term Services & Supports (LTSS)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Long%20Term%20Services%20%26%20Supports%20(LTSS)>)
+- [Member Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Member%20Management)
+- [Pharmacy Benefit Management (PBM) & Point of Sale (POS)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Pharmacy%20Benefit%20Management%20(PBM)%20%26%20Point%20of%20Sale%20(POS)>)
+- [Prescription Drug Monitoring Program (PDMP)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Prescription%20Drug%20Monitoring%20Program%20(PDMP)>)
+- [Provider Management](https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Provider%20Management)
+- [Third Party Liability (TPL)](<https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/Outcomes%20and%20Metrics/Third%20Party%20Liability%20(TPL)>)
 
-*Certification is still required if your project does not fall neatly into one of the above business areas. You may still find relevant outcomes and metrics examples across business areas. As needed, work with your state team and State Officer to create state-specific outcomes statements.* 
-
-
-
-
+_Certification is still required if your project does not fall neatly into one of the above business areas. You may still find relevant outcomes and metrics examples across business areas. As needed, work with your state team and State Officer to create state-specific outcomes statements._


### PR DESCRIPTION
This pull request resolves #81 

**This pull request changes...**
- URLs for certain links in the main project Readme, GitHub repo issues, and the GitHub repo wiki to continue to point to this repo always (which has been renamed Staging) even when hosted on Prod (so that you don't have to look for issues, PRs, etc in more than one place)
- URLs for the links that should always point to same repo/environment they're in
- A few typos that would've probably created a merge conflict because they're on the same lines as the links

**Steps to manually review and verify this change...**
We have a staging server now! Check it out on: https://cmsgov.github.io/CMCS-DSG-DSS-Certification-Staging/

### This pull request can be merged when…
- [x] The above pull request description is complete
- [x] The pull request author has tested the change successfully
- [x] The pull request author has assigned a CMS reviewer
- [x] The change has been reviewed and approved by CMS
