### PR TITLE
Fix sidenav links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,11 @@
 # This config controls the live site.
 
-title: FIXME Site Title
+title: "CMCS-DSG-DSS-Certification"
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
-  FIXME Project Description
-baseurl: "/CMCS-DSG-DSS-Certification"
+  Welcome to the MES Certification Repository, a collaborative community for CMS, states, and vendors.
+# this should page the repository name, available at site.github.repository_name, with a prepended slash
+baseurl: "/CMCS-DSG-DSS-Certification-Staging"
 url: ""
 # twitter_username: jekyllrb
 # github_username:  jekyll

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
           "
         >
           <img
-            src="{{'/assets/images/cms-logo-white.png' | prepend: site.baseurl }}"
+            src="{{'/assets/images/cms-logo-white.png' | prepend: site.github.repository_name | prepend: '/'}}"
             width="200px"
             alt=""
           />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
 >
   <h1 class="ds-h3 ds-u-margin-bottom--0">
     <img
-      src="{{'/assets/images/cms-logo-white.png' | prepend: site.baseurl }}"
+      src="{{'/assets/images/cms-logo-white.png' | prepend: site.github.repository_name | prepend: '/'}}"
       width="200px"
       class="ds-u-valign--middle"
       alt=""

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -16,7 +16,7 @@
   <ul class="ds-c-vertical-nav__subnav" id="collapsible_for_{{forloop.index}}">
     {% for sub in item.items %}
     <li class="ds-c-vertical-nav__item">
-      <a class="ds-c-vertical-nav__label" href="{{ "/" | append: item.subdir | append: "/" | append: sub.title | prepend: site.baseurl }}">
+      <a class="ds-c-vertical-nav__label" href="/{{ site.github.repository_name }}/{{ item.subdir }}/{{ sub.title | urlencode }}">
         {{ sub.title }}
       </a>
     </li>
@@ -26,7 +26,7 @@
 {% else %}
 <li class="ds-c-vertical-nav__item">
   {% if item.link %}
-    <a class="ds-c-vertical-nav__label" href="{{ item.link | urlencode | prepend: site.baseurl }}">
+    <a class="ds-c-vertical-nav__label" href="/{{ site.github.repository_name }}{{ item.link | urlencode }}">
       {{ item.title }}
     </a>
   {% elsif item.url %}
@@ -39,10 +39,9 @@
 </li>
 {% endif %}
 {% endfor %}
-
 <script
   id="toc-script"
   type="text/javascript"
-  src="{{ "/assets/js/toc-expand-collapse.js" | prepend: site.baseurl }}"
-  data-path="{{ site.baseurl }}"
+  src="{{ "/assets/js/toc-expand-collapse.js" | prepend: site.github.repository_name | prepend: '/' }}"
+  data-path="/{{ site.github.repository_name }}"
 ></script>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -4,7 +4,7 @@
   <button
     class="
       ds-c-vertical-nav__label
-      ds-c-vertical-nav__label--current
+      {% if page.url contains item.subdir %} ds-c-vertical-nav__label--current {% endif %}
       ds-c-vertical-nav__label--parent
     "
     title="Collapse sub-navigation"
@@ -15,8 +15,10 @@
   </button>
   <ul class="ds-c-vertical-nav__subnav" id="collapsible_for_{{forloop.index}}">
     {% for sub in item.items %}
+    {% assign filename =  page.path | remove: item.subdir | remove: "readme.md" | remove: "/" %}
     <li class="ds-c-vertical-nav__item">
-      <a class="ds-c-vertical-nav__label" href="/{{ site.github.repository_name }}/{{ item.subdir }}/{{ sub.title | urlencode }}">
+      <a class="ds-c-vertical-nav__label {% if filename == sub.title  %} ds-c-vertical-nav__label--current {% endif %}" 
+        href="/{{ site.github.repository_name }}/{{ item.subdir }}/{{ sub.title | urlencode }}">
         {{ sub.title }}
       </a>
     </li>
@@ -24,9 +26,15 @@
   </ul>
 </li>
 {% else %}
+{%- assign is_current = false -%}
+{%- assign page_url = page.url | remove: ".html" -%}
+{%- if item.link == page_url -%}
+  {%- assign is_current = true -%}
+{%- endif -%}
 <li class="ds-c-vertical-nav__item">
   {% if item.link %}
-    <a class="ds-c-vertical-nav__label" href="/{{ site.github.repository_name }}{{ item.link | urlencode }}">
+    <a class="ds-c-vertical-nav__label {% if is_current %} ds-c-vertical-nav__label--current {% endif %}" 
+      href="/{{ site.github.repository_name }}{{ item.link | urlencode }}">
       {{ item.title }}
     </a>
   {% elsif item.url %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="{{ "/assets/css/index.css" | prepend: site.baseurl }}">
-    <link rel="stylesheet" href="{{ "/main.css" | prepend: site.baseurl }}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/images/favicon-32x32.png" | prepend: site.baseurl }}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{{ "/assets/images/favicon-16x16.png" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/assets/css/index.css" | prepend: site.github.repository_name | prepend: '/'}}">
+    <link rel="stylesheet" href="{{ "/main.css" | prepend: site.github.repository_name | prepend: '/'}}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/images/favicon-32x32.png" | prepend: site.github.repository_name | prepend: '/'}}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ "/assets/images/favicon-16x16.png" | prepend: site.github.repository_name | prepend: '/'}}">
     <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -41,7 +41,7 @@
       </div>
     </main>
     {%include footer.html %}
-    <script src="{{ "/assets/components/index.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "/assets/components/index.js" | prepend: site.github.repository_name | prepend: '/'}}"></script>
     <script type="text/javascript">
       (function makeTablesComplyWithDesignSystem() {
         Array.from(document.querySelectorAll("table")).forEach(function(table) {


### PR DESCRIPTION
## TL;DR: Fixes Staging links
This pull request uses the repo name to inform the root-relative urls in the sidenav and across the site, so that links on Staging will point to Staging and not Production. It also now shows the current/active page in the left sidenav.

### This pull request changes...
- the default `site.baseurl` has been changed to the staging repo name, which is only really used for local development. GitHub Pages ignores this value when deciding where to host the site, using the repo name as the base path instead. Unfortunately, it still generates all the interior pages using the original `site.baseurl` value, which is how you can end up with a repo hosted at `/X/...` and all `site.baseurl`-prepended links with `/Y/...`.
- For links to pages and assets across the site, the URLs now use the repo name (`site.github.repository_name`) rather than using `site.baseurl`, ensuring that no matter which repo the build runs on, it uses the correct path. This value comes from GitHub during the build, so it should be always in sync with the deployment environment.
- Sidenav links now show whether they're the current page (or the parent of a current page).

**Please note that should we start to host this on a subdomain, the references to `site.github.repository_name` as well as `site.baseurl` should be removed.** Also, it would be necessary to have two subdomains, one for prod and one for staging.

**Steps to manually review and verify this change...**
1. Unfortunately, this is the kind of change that has to be tested by deploying. Please contact me if you have any questions, and I'd like to be present for the merges both to staging and to main.

### This pull request can be merged when…
- [x] The above pull request description is complete
- [ ] The pull request author has tested the change successfully
- [x] The pull request author has assigned a CMS reviewer
- [x] The change has been reviewed and approved by CMS

#### Notes
- https://jekyll.github.io/github-metadata/site.github/
- http://jekyllrb.com/docs/github-pages/
- https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/