### PR TITLE
Page header fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,3 +35,7 @@ defaults:
       path: "/Outcomes and Metrics/*/*.csv"
     values:
       layout: "csv"
+
+titles_from_headings:
+  enabled: true
+  strip_title: true

--- a/certification-process.md
+++ b/certification-process.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-# Incorporating outcome statements into CMS Processes
+# Outcomes + the certification process
 Outcomes statements and metrics are part of the Advance Planning Document (APD) process and the draft Streamlined Modular Certification (SMC) process. The program outcomes a state hopes to realize with a proposed Medicaid Enterprise Systems (MES) project not only serve as justification for the investment, but also serve as a way to measure whether or not a project was a success. Not all projects require certification and not all APDs require outcomes. The following is a general overview of when outcomes and metrics are applicable to the APD process and the certification process.
 
 ## APD process 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,0 @@
----
-title: Introduction
-description: This is a documentation page.
-layout: post
----
-
-{% include_relative readme.md %}

--- a/writing-outcome-statements.md
+++ b/writing-outcome-statements.md
@@ -1,5 +1,4 @@
-# What Makes a Good Outcome Statement?
-
+# Writing a good outcomes statement
 To meet the standards of recent CMS guidance, all enhanced funding requests should include written outcomes statements and metrics. A great outcome statement should provide clear answers to the following questions: 
 
 ## 1. What is the benefit to Medicaid?


### PR DESCRIPTION
This pull request resolves #93 

**This pull request changes...**
- No more duplicate h1s across the markdown pages, using the plugin's Strip Titles setting: https://github.com/benbalter/jekyll-titles-from-headings#stripping-titles

Alternatively, you could set the titles manually using YAML front matter, which would make each page start with:
```yaml
---
title: Page title here
---
```
But it's quite a heavy-handed approach, so I think using the automatic page title plugin is a better bet.

**Steps to manually review and verify this change...**
1. Review markdown files to ensure that each one begins with `# Page title here` on the _first line_.

### This pull request can be merged when…
- [X] The above pull request description is complete
- [X] The pull request author has tested the change successfully
- [X] The pull request author has assigned a CMS reviewer
- [x] The change has been reviewed and approved by CMS
