### PR TITLE
Restore circleci cfg missing content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,6 @@ jobs:
             - "00:5c:4a:a0:67:2f:28:b1:81:83:b2:d3:40:da:c3:5e"
       # update this line when the repo is renamed
       - run: git remote add prod_repo git@github.com:CMSgov/CMCS-DSG-DSS-Certification.git
-      - run: git config --global user.email "jerome.lee@cms.hhs.gov"
-      - run: git config --global user.name "Jerome Lee"
-      - run: git config pull.rebase false
-      - run: git pull prod_repo main --no-edit
       - run:
           name: "Updating prod"
           command: "git push prod_repo main:main"

--- a/Ongoing Reporting/readme.md
+++ b/Ongoing Reporting/readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The [Medicaid Enterprise Systems (MES) Data Submissions and Intake Process Procedures Manual](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/Ongoing%20Reporting/Metrics%20Procedures%20Manual.pdf) serves as a guide for how MES metric data, reports, and performance information should be submitted by states and processed by the CMS Data Team to support CMS’s goal to have all state metrics included in one database. The process flows described in the document apply to all 13 modules included in the [Streamlining Modular Certification (SMC)](https://www.medicaid.gov/medicaid/data-systems/certification/streamlined-modular-certification/index.html) and the [Electronic Visit Verification (EVV) module under the Outcome Based Certification (OBC)](https://www.medicaid.gov/medicaid/data-systems/certification/electronic-visit-verification-outcome-based-certification/index.html).  
+The [Medicaid Enterprise Systems (MES) Data Submissions and Intake Process Procedures Manual](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/FAQs-and-Ongoing-Reporting/Ongoing%20Reporting/Metrics%20Procedures%20Manual.pdf) serves as a guide for how MES metric data, reports, and performance information should be submitted by states and processed by the CMS Data Team to support CMS’s goal to have all state metrics included in one database. The process flows described in the document apply to all 13 modules included in the [Streamlining Modular Certification (SMC)](https://www.medicaid.gov/medicaid/data-systems/certification/streamlined-modular-certification/index.html) and the [Electronic Visit Verification (EVV) module under the Outcome Based Certification (OBC)](https://www.medicaid.gov/medicaid/data-systems/certification/electronic-visit-verification-outcome-based-certification/index.html).  
  
 In accordance with 42 C.F.R. §§ 433.112(b)(15) and 433.116(b), (c), and (i), states must be capable of producing data, reports, and performance information from and about their MES modules to facilitate evaluation, continuous improvement in business operations, and transparency and accountability, as a condition for receiving enhanced federal matching for MES expenditures. Metrics provide evidence about whether the intended outcomes are achieved through the delivery of a new module or enhancement to an existing module. Metrics reporting enhances transparency and accountability of IT solutions to help ensure the MES and its modules are meeting statutory and regulatory requirements, as well as the state’s program goals. State reporting also gives states and CMS early and ongoing insight into program evaluation and opportunities for continuous improvement. 
  
@@ -18,8 +18,8 @@ Definitions: CMS, Centers for Medicare & Medicaid Services
 
 ### Key Takeaways for States
 
-- States must submit an [Intake Form](https://www.medicaid.gov/medicaid/data-and-systems/downloads/smc-intake-form.xlsx) and [Operational Report Workbook](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/df601d7d6f69113dee473c11eb2baf443e72fff9/Operational%20Report%20Workbook.xlsx) at multiple steps of the certification process and continue building on these documents over time. 
-- [Box](https://cmsbox.account.box.com/login) is the default repository for all operational reports. 
+- States must submit an [Intake Form](https://www.medicaid.gov/medicaid/data-and-systems/downloads/smc-intake-form.xlsx) and operational reports at multiple steps of the certification process and continue building on these documents over time. 
+- [Box](https://cmsbox.account.box.com/login) is the default repository for all operational reports. State are highly encouraged to use the [Operational Report Workbook](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/FAQs-and-Ongoing-Reporting/Operational%20Report%20Workbook.xlsx) to submit their metrics data for operational reporting.
 - Data is checked and validated at multiple steps of the operational reporting process. 
 - Collaboration between the states and CMS is critical to ensure quality metrics and timely reporting. EVV metrics should be submitted quarterly in operational reports, whereas SMC-related metrics should be submitted in operational reports on an annual basis. 
 
@@ -34,7 +34,7 @@ Any systems that were certified prior to the release of SMD # 22-001, are requir
 - [Streamlined Modular Certification](https://www.medicaid.gov/medicaid/data-systems/certification/streamlined-modular-certification/index.html)
 - [Outcomes-based Certification for Electronic Visit Verification (EVV) Systems (PDF)](https://www.medicaid.gov/federal-policy-guidance/downloads/cib102419.pdf)
 - [Box](https://cmsbox.account.box.com/login)
-- [Metrics Procedures Manual](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/Ongoing%20Reporting/Metrics%20Procedures%20Manual.pdf)
+- [Metrics Procedures Manual](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/FAQs-and-Ongoing-Reporting/Ongoing%20Reporting/Metrics%20Procedures%20Manual.pdf)
 - [Metrics FAQs]({{ site.baseurl }}/FAQs/)
 
 ## References

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ The template here contains CMS-required E&E outcomes as an example of how conten
 - [Operational Report Workbook](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/FAQs-and-Ongoing-Reporting/Operational%20Report%20Workbook.xlsx) - An example template states may use for submitting metrics data
 - [Example Certification Request Letter Template](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/SMC%20Certification%20Request%20Letter%20Template.docx) - An example template of the Certification Request Letter that states must submit to CMS to request certification 
 - [Example Monthly Project Status Reporting Template](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/Streamlined%20Modular%20Certification%20Required%20Monthly%20Project%20Status%20Report%20Example%20Template.docx) - An example template states may use to submit required monthly status reports
-- [Example SMC Monthly Project Status Report with T-MSIS Compliance Plan](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/JAMAMIL-PR158/SMC%20Monthly%20Project%20Status%20Report%20Template%20w%20T-MSIS%20Compliance%20Plan.docx) - An example template of a monthly project status report states may use when also reporting on plans for resolving T-MSIS data quality issues  
+- [Example SMC Monthly Project Status Report with T-MSIS Compliance Plan](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/SMC%20Monthly%20Project%20Status%20Report%20Template%20w%20T-MSIS%20Compliance%20Plan.docx) - An example template of a monthly project status report states may use when also reporting on plans for resolving T-MSIS data quality issues  
 
 ## Recent Updates
 

--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,10 @@ The template here contains CMS-required E&E outcomes as an example of how conten
 
 ### Example Templates
 
-- [Operational Report Workbook](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/df601d7d6f69113dee473c11eb2baf443e72fff9/Operational%20Report%20Workbook.xlsx) - An example template states may use for submitting metrics data
+- [Operational Report Workbook](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/FAQs-and-Ongoing-Reporting/Operational%20Report%20Workbook.xlsx) - An example template states may use for submitting metrics data
 - [Example Certification Request Letter Template](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/SMC%20Certification%20Request%20Letter%20Template.docx) - An example template of the Certification Request Letter that states must submit to CMS to request certification 
 - [Example Monthly Project Status Reporting Template](https://github.com/CMSgov/CMCS-DSG-DSS-Certification/raw/main/Streamlined%20Modular%20Certification%20Required%20Monthly%20Project%20Status%20Report%20Example%20Template.docx) - An example template states may use to submit required monthly status reports
+- [Example SMC Monthly Project Status Report with T-MSIS Compliance Plan](https://github.com/CMSgov/CMCS-DSG-DSS-Certification-Staging/raw/JAMAMIL-PR158/SMC%20Monthly%20Project%20Status%20Report%20Template%20w%20T-MSIS%20Compliance%20Plan.docx) - An example template of a monthly project status report states may use when also reporting on plans for resolving T-MSIS data quality issues  
 
 ## Recent Updates
 


### PR DESCRIPTION
Removes extra CircleCI code that rebased staging against prod

Restored readme files from #159 and #150

**This pull request changes...**
- expected change 1
- expected change 2

**Steps to manually review and verify this change...**
1. steps to view and verify change
2. ...
3. ...

### This pull request can be merged when…
- [ ] The above pull request description is complete
- [ ] The pull request author has tested the change successfully
- [ ] The pull request author has assigned a CMS reviewer
- [ ] The change has been reviewed and approved by CMS
