### PR TITLE
Updates CircleCI config.yml file to default to using staging to avoid merge conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - run: git remote add prod_repo git@github.com:CMSgov/CMCS-DSG-DSS-Certification.git
       - run: git config --global user.email "jerome.lee@cms.hhs.gov"
       - run: git config --global user.name "Jerome Lee"
-      - run: git config pull.rebase false
-      - run: git pull prod_repo main --no-edit
+      - run: git fetch origin
+      - run: git merge origin/main --allow-unrelated-histories
       - run:
           name: "Updating prod"
           command: "git push prod_repo main:main"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git config --global user.email "jerome.lee@cms.hhs.gov"
       - run: git config --global user.name "Jerome Lee"
       - run: git fetch origin
-      - run: git merge origin/main --allow-unrelated-histories
+      - run: git merge origin/main --allow-unrelated-histories -X theirs
       - run:
           name: "Updating prod"
           command: "git push prod_repo main:main"


### PR DESCRIPTION
Updates CircleCI config.yml file to default to using staging to avoid merge conflicts

**This pull request changes...**
- Merging to prod should use staging as the master file


**Steps to manually review and verify this change...**
1. Review the run in CircleCI
2. Verify in Production that the changes from Staging have been made

### This pull request can be merged when…
- [ ] The above pull request description is complete
- [ ] The pull request author has tested the change successfully
- [ ] The pull request author has assigned a CMS reviewer
- [ ] The change has been reviewed and approved by CMS
